### PR TITLE
Add Assertions into taskTypes

### DIFF
--- a/src/main/java/duke/taskTypes/Deadline.java
+++ b/src/main/java/duke/taskTypes/Deadline.java
@@ -31,6 +31,8 @@ public class Deadline extends Task{
             throw new EmptyTimeException("\nInvalid timestamp format");
         }
 
+        assert (results.size() > 1);
+
         key = results.get(0);
         if (key.equals("")){
             throw new EmptyDescriptionException("\nMissing description");

--- a/src/main/java/duke/taskTypes/Event.java
+++ b/src/main/java/duke/taskTypes/Event.java
@@ -29,6 +29,7 @@ public class Event extends Task{
         } else if (results.size() == 1) {
             throw new EmptyTimeException("\nInvalid timestamp format");
         }
+        assert (results.size() > 1);
         String key = results.get(0);
         if (key.equals("")) {
             throw new EmptyDescriptionException("\nMissing description");

--- a/src/main/java/duke/taskTypes/Task.java
+++ b/src/main/java/duke/taskTypes/Task.java
@@ -49,6 +49,9 @@ public class Task {
         } else {
             try {
                 String[] timeFormat = input.trim().split(" ");
+
+                assert timeFormat.length == 2;
+
                 this.date = LocalDate.parse(timeFormat[0]);
                 int hoursMins = Integer.parseInt(timeFormat[1]);
                 if (hoursMins <2400 && hoursMins > 0 && hoursMins%100 <60) {

--- a/src/main/java/duke/util/TaskList.java
+++ b/src/main/java/duke/util/TaskList.java
@@ -39,6 +39,9 @@ public class TaskList {
 
         while (look.hasNext()){
             String[] formattedTask = look.next().split(" ", 3);
+
+            assert formattedTask.length == 3;
+
             boolean isDone = (formattedTask[1].equals("T"));
             Task pastTask = Task.empty();
             switch (formattedTask[0]) {


### PR DESCRIPTION
Previously there were assumptions on the length of the formatted
input. There were

Adding assumptions would remind collaborators that the expected
formatted input size

This is to ensure that there will not be any unforeseen exceptions
caused by incorrect formatted input.